### PR TITLE
fix: Submit an edited image without 404 error

### DIFF
--- a/src/main/java/ImageHoster/controller/ImageController.java
+++ b/src/main/java/ImageHoster/controller/ImageController.java
@@ -141,7 +141,9 @@ public class ImageController {
         updatedImage.setDate(new Date());
 
         imageService.updateImage(updatedImage);
-        return "redirect:/images/" + updatedImage.getTitle();
+        //Passing imageID- {id} and image title - {title} when redirecting to /images/{id}/{title} controller
+        // We would be getting 404 error without passing the id and title values
+        return "redirect:/images/" + updatedImage.getId() + '/' + updatedImage.getTitle();
     }
 
 


### PR DESCRIPTION
- It fixes 404 error on submitting the edited image details
- We were getting 404 error on submitting the edited Image
- Issue while redirecting the request without path values which is to be sent to /images/{id}/{title} controller to show the image again with modified details